### PR TITLE
[nborovenskiy][OeX_ES-55]/notes–from all courses are being returned as part of search not just notes from the current–course

### DIFF
--- a/notesapi/v1/search_indexes/backends/__init__.py
+++ b/notesapi/v1/search_indexes/backends/__init__.py
@@ -1,3 +1,3 @@
-from .note import CompoundSearchFilterBackend
+from .note import CompoundSearchFilterBackend, FilteringFilterBackend
 
-__all__ = ('CompoundSearchFilterBackend',)
+__all__ = ('CompoundSearchFilterBackend', 'FilteringFilterBackend')

--- a/notesapi/v1/search_indexes/backends/note.py
+++ b/notesapi/v1/search_indexes/backends/note.py
@@ -29,7 +29,12 @@ class CompoundSearchFilterBackend(CompoundSearchFilterBackendOrigin):
         :rtype: list
         """
         query_params = request.query_params.copy()
-        return list(chain.from_iterable(query_params.getlist(search_param, []) for search_param in self.search_fields))
+        return list(
+            chain.from_iterable(
+                query_params.getlist(search_param, [])
+                for search_param in self.search_fields
+            )
+        )
 
 
 class FilteringFilterBackend(FilteringFilterBackendOrigin):

--- a/notesapi/v1/tests/test_update_index.py
+++ b/notesapi/v1/tests/test_update_index.py
@@ -34,7 +34,7 @@ class UpdateIndexTest(BaseAnnotationViewTests):
 
         results = self._get_search_results(text='note')
         self.assertEqual(results['total'], 3)
-        self.assertEqual(results['rows'][0]['text'], 'First note')
+        self.assertEqual(results['rows'][0]['text'], 'Third note')
 
     @factory.django.mute_signals(signals.post_delete)
     def test_delete(self):

--- a/notesapi/v1/tests/test_views.py
+++ b/notesapi/v1/tests/test_views.py
@@ -964,8 +964,8 @@ class AnnotationSearchViewTests(BaseAnnotationViewTests):
 
         self._create_annotation(text=u'First one. I am a simple note.', course_id="u'edX/DemoX/Demo_Course'")
         self._create_annotation(text=u'Second note. I am a simple note.', course_id="u'edX/DemoX/Demo_Course'")
-        self._create_annotation(text=u'Third note. I am a simple note.', course_id="b")
-        self._create_annotation(text=u'Fourth note. I am a simple note.', course_id="c")
+        self._create_annotation(text=u'Third note. I am a simple note.', course_id='b')
+        self._create_annotation(text=u'Fourth note. I am a simple note.', course_id='c')
 
         @patch('django.conf.settings.ES_DISABLED', is_es_disabled)
         def verify_course_id_search():

--- a/notesapi/v1/utils.py
+++ b/notesapi/v1/utils.py
@@ -3,14 +3,15 @@ Utilities for notes api application
 """
 
 from django.conf import settings
+from django.http import QueryDict
 from rest_framework.response import Response
-from rest_framework.utils.serializer_helpers import ReturnList
 
 
 class NotesPaginatorMixin:
     """
     Student Notes Paginator Mixin
     """
+
     page_size = settings.DEFAULT_NOTES_PAGE_SIZE
     page_size_query_param = "page_size"
 
@@ -18,12 +19,50 @@ class NotesPaginatorMixin:
         """
         Annotate the response with pagination information.
         """
-        return Response({
-            'start': (self.page.number - 1) * self.get_page_size(self.request),
-            'current_page': self.page.number,
-            'next': self.get_next_link(),
-            'previous': self.get_previous_link(),
-            'total': self.page.paginator.count,
-            'num_pages': self.page.paginator.num_pages,
-            'rows': data
-        })
+        return Response(
+            {
+                'start': (self.page.number - 1) * self.get_page_size(self.request),
+                'current_page': self.page.number,
+                'next': self.get_next_link(),
+                'previous': self.get_previous_link(),
+                'total': self.page.paginator.count,
+                'num_pages': self.page.paginator.num_pages,
+                'rows': data,
+            }
+        )
+
+
+def dict_to_querydict(dict_):
+    """
+    Converts a dict value into a Django's QueryDict object.
+    """
+    query_dict = QueryDict("", mutable=True)
+    for name, value in dict_.items():
+        if isinstance(name, list):
+            query_dict.setlist(name, value)
+        else:
+            query_dict.appendlist(name, value)
+    query_dict._mutable = False
+    return query_dict
+
+
+class Request:
+    """
+    Specifies custom behavior of the standard Django request class.
+
+    Implementation of the `duck typing` pattern.
+    Using an object of class `Request` allows you to define the desired logic,
+    which will be different from Django's Request.
+    Those program components that are expecting a Django request,
+    but they will use `Request` - will not notice the substitution at all.
+    """
+
+    def __init__(self, query_params):
+        self._query_params = query_params
+
+    @property
+    def query_params(self):
+        """
+        Returns the Django's QueryDict object, which presents request's query params.
+        """
+        return dict_to_querydict(self._query_params)

--- a/notesapi/v1/utils.py
+++ b/notesapi/v1/utils.py
@@ -34,9 +34,9 @@ class NotesPaginatorMixin:
 
 def dict_to_querydict(dict_):
     """
-    Converts a dict value into a Django's QueryDict object.
+    Converts a dict value into the Django's QueryDict object.
     """
-    query_dict = QueryDict("", mutable=True)
+    query_dict = QueryDict('', mutable=True)
     for name, value in dict_.items():
         if isinstance(name, list):
             query_dict.setlist(name, value)
@@ -48,7 +48,7 @@ def dict_to_querydict(dict_):
 
 class Request:
     """
-    Specifies custom behavior of the standard Django request class.
+    Specifies custom behavior of the standard Django's request class.
 
     Implementation of the `duck typing` pattern.
     Using an object of class `Request` allows you to define the desired logic,


### PR DESCRIPTION
**Description:** This PR fixes a bug 'Notes from all courses are being returned as part of search, not just notes from the current course'. 

Also, it adds for es output:
- filtering by course_id, user, usage_id
- default ordering by descending 'updated' attribute
- adds tests to cover our problem and others (user, usage_id). Thus, we will test and search with filtering through both MySQL and ES.

**Youtrack:** https://youtrack.raccoongang.com/issue/OeX_ES-55

**Reviewers:**
- @idegtiarov 
- @Golub-Sergey 
- @dianakhuang 
- @mterry

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Documentation in source code updated
- [x] All related Confluence documentation is updated (including deployment documentation)
- [ ] Commits are squashed

**Post merge:**
- Delete working branch
